### PR TITLE
Optimizes scatterplot SQL

### DIFF
--- a/app/scripts/views/chart.js
+++ b/app/scripts/views/chart.js
@@ -46,12 +46,13 @@ define([
       var data = new DataCollection({
         username: urlParams.username
       });
-      var template = _.template('SELECT <%= columns %> FROM <%= table %>');
+      var template = _.template('SELECT <%= columnA %>, <%= columnB %>, COUNT((<%= columnA %>,<%= columnB %>)) AS density FROM <%= table %> GROUP BY <%= columnA %>,<%= columnB %>');
       data.fetch({
         data: {
           q: this.params.query || template({
             table: this.params.table,
-            columns: [this.params.xcolumn, this.params.ycolumn].join(',')
+            columnA: this.params.xcolumn,
+            columnB: this.params.ycolumn
           }),
           apikey: urlParams.apikey
         },


### PR DESCRIPTION
Instead of selecting all the points we can query just for unique x,y combinations, and add a "density" field in case we want to use it in the chart. This will mean less points to draw in svg.

In many cases however we will still have too many points for the browser to handle, so we can think of re-writing this query in a way we can lower data resolution, add max, min or category filters, etc. The idea is that if the result of a query contains too many points (due to memory or just because they won't fit reasonably in the chart) we give the user options by either lowering the resolution or filtering the dataset.

The query would then look something like this:

with table as
( SELECT 
-- We can round, average or use other functions etc. to lower resolution or aggregate
function(columnA) as x, 
function(columnA) as y
FROM selectedTable 
WHERE
-- max, min and category filters go here
)
--And then 
SELECT x,y, COUNT((x,y)) AS density FROM table GROUP BY x,y
